### PR TITLE
feat: add option to import bookmarks

### DIFF
--- a/apps/client/src/entities/bookmark/ui/bookmark-import-form/bookmark-import-form.tsx
+++ b/apps/client/src/entities/bookmark/ui/bookmark-import-form/bookmark-import-form.tsx
@@ -38,7 +38,7 @@ export function ImportBookmarkForm({
               name="importFile"
               control={control}
               render={({ field }) => (
-                 <Input
+                <Input
                   id="importFile"
                   type="file"
                   accept=".html"
@@ -50,7 +50,9 @@ export function ImportBookmarkForm({
                 />
               )}
             />
-            {errors.importFile && <p className="text-red-500">{errors.importFile.message}</p>}
+            {errors.importFile && (
+              <p className="text-red-500">{errors.importFile.message}</p>
+            )}
           </div>
           <div className="space-y-1.5">
             <Label htmlFor="collection">Collection</Label>

--- a/apps/client/src/entities/bookmark/ui/bookmark-import-form/bookmark-import-form.tsx
+++ b/apps/client/src/entities/bookmark/ui/bookmark-import-form/bookmark-import-form.tsx
@@ -1,4 +1,4 @@
-import type { ImportBookmarkForm } from "./types";
+import type { ImportForm } from "./types";
 import { Input } from "@/shared/ui/input";
 import { Label } from "@/shared/ui/label";
 import {
@@ -13,11 +13,11 @@ import { Button } from "@/shared/ui/button";
 
 interface Props {
   isSubmitting: boolean;
-  onSubmit: (data: ImportBookmarkForm) => void;
+  onSubmit: (data: ImportForm) => void;
   collections?: { id: string; name: string }[];
 }
 
-export function ImportBookmarkFormUi({
+export function ImportBookmarkForm({
   isSubmitting,
   collections,
   onSubmit,
@@ -26,7 +26,7 @@ export function ImportBookmarkFormUi({
     handleSubmit,
     control,
     formState: { errors },
-  } = useFormContext<ImportBookmarkForm>();
+  } = useFormContext<ImportForm>();
 
   return (
     <form onSubmit={handleSubmit(onSubmit)} className="grid gap-4">

--- a/apps/client/src/entities/bookmark/ui/bookmark-import-form/bookmark-import-form.tsx
+++ b/apps/client/src/entities/bookmark/ui/bookmark-import-form/bookmark-import-form.tsx
@@ -33,16 +33,20 @@ export function ImportBookmarkFormUi({
       <div className="grid grid-cols-1 md:grid-cols-2 relative gap-4">
         <div className="space-y-2">
           <div className="space-y-1.5">
-            <Label htmlFor="url">Import File</Label>
+            <Label htmlFor="importFile">Import File</Label>
             <Controller
               name="importFile"
               control={control}
               render={({ field }) => (
-                <Input
-                  // {...field}
+                 <Input
                   id="importFile"
                   type="file"
                   accept=".html"
+                  onChange={(e) => {
+                    if (e.target.files) {
+                      field.onChange(e.target.files[0]);
+                    }
+                  }}
                 />
               )}
             />
@@ -76,11 +80,6 @@ export function ImportBookmarkFormUi({
             {isSubmitting ? "Importing..." : "Import bookmarks"}
           </Button>
         </div>
-        {/* {isFetching && (
-          <div className="flex backdrop-blur-sm absolute inset-0 bg-background/20 items-center justify-center py-4">
-            <Loader2 size={20} className="animate-spin" />
-          </div>
-        )} */}
       </div>
     </form>
   );

--- a/apps/client/src/entities/bookmark/ui/bookmark-import-form/bookmark-import-form.tsx
+++ b/apps/client/src/entities/bookmark/ui/bookmark-import-form/bookmark-import-form.tsx
@@ -1,0 +1,87 @@
+import type { ImportBookmarkForm } from "./types";
+import { Input } from "@/shared/ui/input";
+import { Label } from "@/shared/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/shared/ui/select";
+import { Controller, useFormContext } from "react-hook-form";
+import { Button } from "@/shared/ui/button";
+
+interface Props {
+  isSubmitting: boolean;
+  onSubmit: (data: ImportBookmarkForm) => void;
+  collections?: { id: string; name: string }[];
+}
+
+export function ImportBookmarkFormUi({
+  isSubmitting,
+  collections,
+  onSubmit,
+}: Props) {
+  const {
+    handleSubmit,
+    control,
+    formState: { errors },
+  } = useFormContext<ImportBookmarkForm>();
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="grid gap-4">
+      <div className="grid grid-cols-1 md:grid-cols-2 relative gap-4">
+        <div className="space-y-2">
+          <div className="space-y-1.5">
+            <Label htmlFor="url">Import File</Label>
+            <Controller
+              name="importFile"
+              control={control}
+              render={({ field }) => (
+                <Input
+                  // {...field}
+                  id="importFile"
+                  type="file"
+                  accept=".html"
+                />
+              )}
+            />
+            {errors.importFile && <p className="text-red-500">{errors.importFile.message}</p>}
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="collection">Collection</Label>
+            <Controller
+              control={control}
+              name="collectionId"
+              render={({ field }) => (
+                <Select
+                  defaultValue={field.value}
+                  onValueChange={field.onChange}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select a default collection" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {collections?.map((collection) => (
+                      <SelectItem value={collection.id} key={collection.id}>
+                        {collection.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
+            />
+          </div>
+          <Button type="submit" className="w-full" disabled={isSubmitting}>
+            {isSubmitting ? "Importing..." : "Import bookmarks"}
+          </Button>
+        </div>
+        {/* {isFetching && (
+          <div className="flex backdrop-blur-sm absolute inset-0 bg-background/20 items-center justify-center py-4">
+            <Loader2 size={20} className="animate-spin" />
+          </div>
+        )} */}
+      </div>
+    </form>
+  );
+}

--- a/apps/client/src/entities/bookmark/ui/bookmark-import-form/index.ts
+++ b/apps/client/src/entities/bookmark/ui/bookmark-import-form/index.ts
@@ -1,0 +1,2 @@
+export * from "./bookmark-import-form";
+export * from "./types";

--- a/apps/client/src/entities/bookmark/ui/bookmark-import-form/types.ts
+++ b/apps/client/src/entities/bookmark/ui/bookmark-import-form/types.ts
@@ -12,4 +12,4 @@ export const importBookmarkSchema = z.object({
   collectionId: z.string().min(1, "Collection is required"),
 });
 
-export type ImportBookmarkForm = z.infer<typeof importBookmarkSchema>;
+export type ImportForm = z.infer<typeof importBookmarkSchema>;

--- a/apps/client/src/entities/bookmark/ui/bookmark-import-form/types.ts
+++ b/apps/client/src/entities/bookmark/ui/bookmark-import-form/types.ts
@@ -1,9 +1,14 @@
 import { z } from "zod";
 
-const ACCEPTED_IMPORT_FILE_TYPE = ['html'];
+const ACCEPTED_IMPORT_FILE_TYPE = ['text/html'];
 
 export const importBookmarkSchema = z.object({
-  importFile: z.instanceof(File).refine((file) => { return ACCEPTED_IMPORT_FILE_TYPE.includes(file.type);}, 'File must be a html file'),
+  importFile: z
+    .custom<File>(val => val instanceof File, 'Please upload a file')
+    .refine(
+      file => ACCEPTED_IMPORT_FILE_TYPE.includes(file.type),
+      { message: 'Please choose .html format files only' }
+    ),
   collectionId: z.string().min(1, "Collection is required"),
 });
 

--- a/apps/client/src/entities/bookmark/ui/bookmark-import-form/types.ts
+++ b/apps/client/src/entities/bookmark/ui/bookmark-import-form/types.ts
@@ -1,14 +1,13 @@
 import { z } from "zod";
 
-const ACCEPTED_IMPORT_FILE_TYPE = ['text/html'];
+const ACCEPTED_IMPORT_FILE_TYPE = ["text/html"];
 
 export const importBookmarkSchema = z.object({
   importFile: z
-    .custom<File>(val => val instanceof File, 'Please upload a file')
-    .refine(
-      file => ACCEPTED_IMPORT_FILE_TYPE.includes(file.type),
-      { message: 'Please choose .html format files only' }
-    ),
+    .custom<File>((val) => val instanceof File, "Please upload a file")
+    .refine((file) => ACCEPTED_IMPORT_FILE_TYPE.includes(file.type), {
+      message: "Please choose .html format files only",
+    }),
   collectionId: z.string().min(1, "Collection is required"),
 });
 

--- a/apps/client/src/entities/bookmark/ui/bookmark-import-form/types.ts
+++ b/apps/client/src/entities/bookmark/ui/bookmark-import-form/types.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+const ACCEPTED_IMPORT_FILE_TYPE = ['html'];
+
+export const importBookmarkSchema = z.object({
+  importFile: z.instanceof(File).refine((file) => { return ACCEPTED_IMPORT_FILE_TYPE.includes(file.type);}, 'File must be a html file'),
+  collectionId: z.string().min(1, "Collection is required"),
+});
+
+export type ImportBookmarkForm = z.infer<typeof importBookmarkSchema>;

--- a/apps/client/src/entities/bookmark/ui/index.ts
+++ b/apps/client/src/entities/bookmark/ui/index.ts
@@ -1,2 +1,3 @@
 export * from "./bookmark-card";
 export * from "./bookmark-form";
+export * from "./bookmark-import-form";

--- a/apps/client/src/features/bookmark/bookmar-modal-import/index.ts
+++ b/apps/client/src/features/bookmark/bookmar-modal-import/index.ts
@@ -1,0 +1,1 @@
+export * from "./ui";

--- a/apps/client/src/features/bookmark/bookmar-modal-import/ui/bookmark-modal-import.tsx
+++ b/apps/client/src/features/bookmark/bookmar-modal-import/ui/bookmark-modal-import.tsx
@@ -1,4 +1,4 @@
-import type { ImportBookmarkForm } from "@/entities/bookmark";
+import type { ImportForm } from "@/entities/bookmark";
 import { Button } from "@/shared/ui/button";
 import { trpc } from "@/shared/trpc";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -12,7 +12,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/shared/ui/dialog";
-import { ImportBookmarkFormUi, importBookmarkSchema } from "@/entities/bookmark";
+import { ImportBookmarkForm, importBookmarkSchema } from "@/entities/bookmark";
 import { useParams, useSearchParams } from "react-router-dom";
 
 export function BookmarkModalImport() {
@@ -20,7 +20,7 @@ export function BookmarkModalImport() {
   const params = useParams();
   const utils = trpc.useUtils();
   const { data: collections } = trpc.collections.list.useQuery();
-  const form = useForm<ImportBookmarkForm>({
+  const form = useForm<ImportForm>({
     resolver: zodResolver(importBookmarkSchema),
     defaultValues: {
       importFile: undefined,
@@ -41,7 +41,7 @@ export function BookmarkModalImport() {
     },
   });
 
-  async function submit(data: ImportBookmarkForm) {
+  async function submit(data: ImportForm) {
     const importedBookmarks: {url: string, collectionId: string}[] = [];
 
     // To read the imported bookmark file
@@ -105,7 +105,7 @@ export function BookmarkModalImport() {
           </DialogDescription>
         </DialogHeader>
         <FormProvider {...form}>
-          <ImportBookmarkFormUi
+          <ImportBookmarkForm
             isSubmitting={create.isPending}
             collections={collections}
             onSubmit={submit}

--- a/apps/client/src/features/bookmark/bookmar-modal-import/ui/bookmark-modal-import.tsx
+++ b/apps/client/src/features/bookmark/bookmar-modal-import/ui/bookmark-modal-import.tsx
@@ -30,6 +30,7 @@ export function BookmarkModalImport() {
   const create = trpc.bookmarks.import.useMutation({
     onSuccess() {
       utils.bookmarks.list.invalidate();
+      utils.collections.list.invalidate();
       utils.stats.all.invalidate();
       setSearchParams((prev) => {
         prev.delete("modal");

--- a/apps/client/src/features/bookmark/bookmar-modal-import/ui/bookmark-modal-import.tsx
+++ b/apps/client/src/features/bookmark/bookmar-modal-import/ui/bookmark-modal-import.tsx
@@ -1,0 +1,85 @@
+import type { ImportBookmarkForm } from "@/entities/bookmark";
+import { Button } from "@/shared/ui/button";
+import { trpc } from "@/shared/trpc";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { FormProvider, useForm } from "react-hook-form";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/shared/ui/dialog";
+import { ImportBookmarkFormUi, importBookmarkSchema } from "@/entities/bookmark";
+import { useParams, useSearchParams } from "react-router-dom";
+
+export function BookmarkModalImport() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const params = useParams();
+  const utils = trpc.useUtils();
+  const { data: collections } = trpc.collections.list.useQuery();
+  const form = useForm<ImportBookmarkForm>({
+    resolver: zodResolver(importBookmarkSchema),
+    defaultValues: {
+      collectionId: "",
+    },
+  });
+
+//   const create = trpc.bookmarks.create.useMutation({
+//     onSuccess() {
+//       utils.bookmarks.list.invalidate();
+//       utils.collections.list.invalidate();
+//       utils.stats.all.invalidate();
+//       setSearchParams((prev) => {
+//         prev.delete("modal");
+//         return prev;
+//       });
+//       form.reset();
+//     },
+//   });
+
+  function submit(data: ImportBookmarkForm) {
+    // create.mutate(data);
+  }
+
+  function onOpenChange(open: boolean) {
+    if (!open) {
+      form.reset();
+    } else {
+      form.setValue("collectionId", params.collection_id || "");
+    }
+
+    setSearchParams((prev) => {
+      open ? prev.set("modal", "import-bookmark") : prev.delete("modal");
+
+      return prev;
+    });
+  }
+
+  return (
+    <Dialog
+      open={searchParams.get("modal") === "import-bookmark"}
+      onOpenChange={onOpenChange}
+    >
+      <DialogTrigger asChild>
+        <Button className="w-full">Import Bookmark </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-5xl">
+        <DialogHeader>
+          <DialogTitle>Import bookmark</DialogTitle>
+          <DialogDescription>
+            Upload the bookmarks file to import
+          </DialogDescription>
+        </DialogHeader>
+        <FormProvider {...form}>
+          <ImportBookmarkFormUi
+            isSubmitting={true}
+            collections={collections}
+            onSubmit={submit}
+          />
+        </FormProvider>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/client/src/features/bookmark/bookmar-modal-import/ui/bookmark-modal-import.tsx
+++ b/apps/client/src/features/bookmark/bookmar-modal-import/ui/bookmark-modal-import.tsx
@@ -43,35 +43,38 @@ export function BookmarkModalImport() {
   });
 
   async function submit(data: ImportForm) {
-    const importedBookmarks: {url: string, collectionId: string}[] = [];
+    const importedBookmarks: { url: string; collectionId: string }[] = [];
 
     // To read the imported bookmark file
     const reader = new FileReader();
-    
+
     reader.onload = function (e) {
       // To parse the html content of the imported bookmark file
       const parser = new DOMParser();
 
-      if (!e?.target?.result){
+      if (!e?.target?.result) {
         toast.error("Something went wrong.");
         return;
       }
 
-      const doc = parser.parseFromString(e.target.result.toString(), 'text/html');
-      const hrefElements = doc.querySelectorAll('[HREF]');
+      const doc = parser.parseFromString(
+        e.target.result.toString(),
+        "text/html",
+      );
+      const hrefElements = doc.querySelectorAll("[HREF]");
 
-      hrefElements.forEach(element => {
-        const bookmarkUrl = element.getAttribute('HREF');
+      hrefElements.forEach((element) => {
+        const bookmarkUrl = element.getAttribute("HREF");
         if (bookmarkUrl) {
           importedBookmarks.push({
-            'url': bookmarkUrl,
-            'collectionId': data.collectionId
+            url: bookmarkUrl,
+            collectionId: data.collectionId,
           });
         }
       });
 
       create.mutate(importedBookmarks);
-    }
+    };
 
     await reader.readAsText(data.importFile);
   }
@@ -96,8 +99,8 @@ export function BookmarkModalImport() {
       onOpenChange={onOpenChange}
     >
       <DialogTrigger asChild>
-        <Button variant='outline' className="px-2">
-          <Upload/>
+        <Button variant="outline" className="px-2">
+          <Upload />
         </Button>
       </DialogTrigger>
       <DialogContent className="sm:max-w-xl">

--- a/apps/client/src/features/bookmark/bookmar-modal-import/ui/bookmark-modal-import.tsx
+++ b/apps/client/src/features/bookmark/bookmar-modal-import/ui/bookmark-modal-import.tsx
@@ -1,4 +1,5 @@
 import type { ImportForm } from "@/entities/bookmark";
+import { Upload } from "lucide-react";
 import { Button } from "@/shared/ui/button";
 import { trpc } from "@/shared/trpc";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -95,9 +96,11 @@ export function BookmarkModalImport() {
       onOpenChange={onOpenChange}
     >
       <DialogTrigger asChild>
-        <Button className="w-full">Import Bookmark </Button>
+        <Button variant='outline' size='sm'>
+          <Upload/>
+        </Button>
       </DialogTrigger>
-      <DialogContent className="sm:max-w-5xl">
+      <DialogContent className="sm:max-w-xl">
         <DialogHeader>
           <DialogTitle>Import bookmark</DialogTitle>
           <DialogDescription>

--- a/apps/client/src/features/bookmark/bookmar-modal-import/ui/bookmark-modal-import.tsx
+++ b/apps/client/src/features/bookmark/bookmar-modal-import/ui/bookmark-modal-import.tsx
@@ -96,7 +96,7 @@ export function BookmarkModalImport() {
       onOpenChange={onOpenChange}
     >
       <DialogTrigger asChild>
-        <Button variant='outline' size='sm'>
+        <Button variant='outline' className="px-2">
           <Upload/>
         </Button>
       </DialogTrigger>

--- a/apps/client/src/features/bookmark/bookmar-modal-import/ui/bookmark-modal-import.tsx
+++ b/apps/client/src/features/bookmark/bookmar-modal-import/ui/bookmark-modal-import.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/shared/ui/button";
 import { trpc } from "@/shared/trpc";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { FormProvider, useForm } from "react-hook-form";
+import { toast } from "sonner";
 import {
   Dialog,
   DialogContent,
@@ -41,7 +42,7 @@ export function BookmarkModalImport() {
   });
 
   async function submit(data: ImportBookmarkForm) {
-    let importedBookmarks: {url: string, collectionId: string}[] = [];
+    const importedBookmarks: {url: string, collectionId: string}[] = [];
 
     // To read the imported bookmark file
     const reader = new FileReader();
@@ -50,8 +51,9 @@ export function BookmarkModalImport() {
       // To parse the html content of the imported bookmark file
       const parser = new DOMParser();
 
-      if (e?.target?.result === null || e.target === null){
-        return console.error('File is empty');
+      if (!e?.target?.result){
+        toast.error("Something went wrong.");
+        return;
       }
 
       const doc = parser.parseFromString(e.target.result.toString(), 'text/html');
@@ -59,7 +61,7 @@ export function BookmarkModalImport() {
 
       hrefElements.forEach(element => {
         const bookmarkUrl = element.getAttribute('HREF');
-        if (bookmarkUrl !== null) {
+        if (bookmarkUrl) {
           importedBookmarks.push({
             'url': bookmarkUrl,
             'collectionId': data.collectionId

--- a/apps/client/src/features/bookmark/bookmar-modal-import/ui/index.ts
+++ b/apps/client/src/features/bookmark/bookmar-modal-import/ui/index.ts
@@ -1,0 +1,1 @@
+export * from "./bookmark-modal-import";

--- a/apps/client/src/widgets/sidebar/sidebar.tsx
+++ b/apps/client/src/widgets/sidebar/sidebar.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/shared/ui/button";
 import { PanelRightOpen } from "lucide-react";
 import { useEffect } from "react";
 import { useLocation } from "react-router-dom";
+import { BookmarkModalImport } from "@/features/bookmark/bookmar-modal-import";
 
 export function Sidebar() {
   const location = useLocation();
@@ -46,6 +47,7 @@ export function Sidebar() {
         <ProfileMenu onLogout={() => logout.mutate()} profile={profile} />
         <Separator />
         <BookmarkModalAdd />
+        <BookmarkModalImport />
         <CollectionsList />
       </div>
     </aside>

--- a/apps/client/src/widgets/sidebar/sidebar.tsx
+++ b/apps/client/src/widgets/sidebar/sidebar.tsx
@@ -46,8 +46,10 @@ export function Sidebar() {
       <div className="space-y-4">
         <ProfileMenu onLogout={() => logout.mutate()} profile={profile} />
         <Separator />
-        <BookmarkModalAdd />
-        <BookmarkModalImport />
+        <div className="flex gap-2">
+          <BookmarkModalAdd />
+          <BookmarkModalImport />
+        </div>
         <CollectionsList />
       </div>
     </aside>

--- a/apps/server/src/routes/bookmarks.ts
+++ b/apps/server/src/routes/bookmarks.ts
@@ -22,7 +22,7 @@ export const bookmarksRouter = t.router({
         collectionId: z.string().optional(),
         query: z.string().optional(),
         tags: z.array(z.string()).optional(),
-      })
+      }),
     )
     .query(async ({ ctx: { user }, input }) => {
       let bookmarksByTags: string[] = [];
@@ -31,7 +31,7 @@ export const bookmarksRouter = t.router({
         const collection = await db.query.collections.findFirst({
           where: and(
             eq(collections.ownerId, user.id),
-            eq(collections.id, input.collectionId)
+            eq(collections.id, input.collectionId),
           ),
         });
 
@@ -64,7 +64,7 @@ export const bookmarksRouter = t.router({
           ...(input.query ? [ilike(bookmarks.title, `%${input.query}%`)] : []),
           ...(bookmarksByTags?.length
             ? [inArray(bookmarks.id, bookmarksByTags)]
-            : [])
+            : []),
         ),
         with: {
           tags: {
@@ -97,13 +97,15 @@ export const bookmarksRouter = t.router({
       return bookmark;
     }),
   import: authedProcedure
-    .input(z.array(z.object({url: z.string(), collectionId: z.string()})))
+    .input(z.array(z.object({ url: z.string(), collectionId: z.string() })))
     .mutation(async ({ ctx: { user }, input }) => {
-      const importedBoomarks = await Promise.all(input.map(async (bookmarkData) => {
-        const parsedBookmarkData = await parser(bookmarkData.url);
-        return { ...bookmarkData, ...parsedBookmarkData, ownerId: user.id};
-      }));
-      
+      const importedBoomarks = await Promise.all(
+        input.map(async (bookmarkData) => {
+          const parsedBookmarkData = await parser(bookmarkData.url);
+          return { ...bookmarkData, ...parsedBookmarkData, ownerId: user.id };
+        }),
+      );
+
       const [bookmark] = await db
         .insert(bookmarks)
         .values(importedBoomarks)
@@ -146,8 +148,8 @@ export const bookmarksRouter = t.router({
         .where(
           and(
             eq(bookmarksTags.bookmarkId, input.bookmarkId),
-            eq(bookmarksTags.tagId, input.tagId)
-          )
+            eq(bookmarksTags.tagId, input.tagId),
+          ),
         );
     }),
   delete: authedProcedure

--- a/apps/server/src/routes/bookmarks.ts
+++ b/apps/server/src/routes/bookmarks.ts
@@ -96,6 +96,21 @@ export const bookmarksRouter = t.router({
 
       return bookmark;
     }),
+  import: authedProcedure
+    .input(z.array(z.object({url: z.string(), collectionId: z.string()})))
+    .mutation(async ({ ctx: { user }, input }) => {
+      const importedBoomarks = await Promise.all(input.map(async (bookmarkData) => {
+        const parsedBookmarkData = await parser(bookmarkData.url);
+        return { ...bookmarkData, ...parsedBookmarkData, ownerId: user.id};
+      }));
+      
+      const [bookmark] = await db
+        .insert(bookmarks)
+        .values(importedBoomarks)
+        .returning();
+
+      return bookmark;
+    }),
   update: authedProcedure
     .input(bookmarkInputSchema.extend({ id: z.string() }))
     .mutation(async ({ input }) => {


### PR DESCRIPTION
Description:
Added the feature to import the bookmarks from the 'exported bookmark file from a browser'

Approach:
We had two approaches to build the solution
1) Upload the file to the server, and let the server read the file content and insert the bookmarks.
  - I proceeded with this method first, but turns out tRPC doesn't natively support passing files (Read [this ](https://stackoverflow.com/questions/76105855/send-blob-image-from-frontend-to-backend-with-nextjs-and-trpc-t3-stack)& [this](https://nehalist.io/trpc-review/#uploading-files))
  - A turnaround was to add a separate dedicated route for this and use traditional REST methods.
  - But this would mean, tweaking the whole architecture, and supporting two different methods.

2) Upload the file to the client, extract bookmark URLs & send it as an array of objects to the server.
- Proceeded with this method.
- First, the client reads the file and extracts all the bookmarks, which are later on sent to the server.
- The server processes each URL & fetches the metadata (Something which can be improved later on)
- The server bulk inserts all the imported URLs.

Is this the right approach or should we go with the first option or something else?

Video:

https://github.com/unimarkapp/unimark.app/assets/63875632/9e941d71-4756-4d8d-94f3-f526e689c48e

Open issue(s): 
- The import is taking too much of time, mostly because of fetching the metadata. The attached video imports 182 Bookmarks - How to take care of this?
- Not all metadata's are fetched correctly, this is also true for adding single bookmark(will create a separate issue for this).
- The UI of the Import Bookmark modal - Will modify it a bit, keeping everything in centre & a small modal screen, does that sound good?